### PR TITLE
Fix broken binary secrets for Google Authenticator

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 ====
 
-**Copyright (c) 2014 Nicolas Jessel**
+**Copyright (c) 2014 Nicolas Jessel, Google LLC**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/components/GoogleAuthenticator.js
+++ b/lib/components/GoogleAuthenticator.js
@@ -41,13 +41,13 @@ var GoogleAuthenticator = function GoogleAuthenticator()
          *
          * @param {@code secret} base 32 secret will be decoded
          *
-         * @return secret string
+         * @return secret hex string
          */
         decode:
         {
             value: function (base32Secret)
             {
-                return base32.decode(base32Secret).toString();
+                return base32.decode(base32Secret).toString('hex');
             },
             enumerable: true
         },
@@ -180,7 +180,7 @@ var GoogleAuthenticator = function GoogleAuthenticator()
                 // ensure uniformity
                 _secret = _secret.toUpperCase();
 
-                return TOTP.gen({string:self.decode(_secret)});
+                return TOTP.gen({hex:self.decode(_secret)});
             },
             enumerable: true
         },

--- a/test/unit/GoogleAuthenticatorTest.js
+++ b/test/unit/GoogleAuthenticatorTest.js
@@ -223,9 +223,14 @@ describe('- GoogleAuthenticatorTest file', function()
                 unit.function(GoogleAuthenticator.decode);
             });
 
-            it('- call `decode` to check if the result is a string', function()
+            it('- call `decode` to check if the result is a hex string', function()
             {
-                unit.assert.equal(GoogleAuthenticator.decode('NVXW4IDTMVRXEZLU'), 'mon secret');
+                unit.assert.equal(GoogleAuthenticator.decode('NVXW4IDTMVRXEZLU'), Buffer.from('mon secret').toString('hex'));
+            });
+
+            it('- call `decode` to check for properly decoded binary secrets', function()
+            {
+                unit.assert.equal(GoogleAuthenticator.decode('JBSWY3DPEHPK3PXP'), '48656c6c6f21deadbeef');
             });
         });
 


### PR DESCRIPTION
This fixes the decoding of base32 secrets which contain non-ascii characters. It now calls `toString` with the hex format specified, then passes the hex into the `TOTP.gen` function, again specifying hex as the format.

I have used the examples listed [here](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#examples) to verify that it works properly, and I have added this secret to Google Authenticator to verify that I see the same TOTPs generated with this modification.